### PR TITLE
(feat): add camera permissions & fix for iOS - allowsEditing: true

### DIFF
--- a/apps/expo/app.config.ts
+++ b/apps/expo/app.config.ts
@@ -22,17 +22,12 @@ const defineConfig = (_ctx: ConfigContext): ExpoConfig => ({
   ios: {
     supportsTablet: true,
     bundleIdentifier: "your.bundle.identifier",
-    infoPlist: {
-      NSPhotoLibraryUsageDescription:
-        "This app needs access to your photo library for OCR processing.",
-    },
   },
   android: {
     adaptiveIcon: {
       foregroundImage: "./assets/icon.png",
       backgroundColor: "#ffffff",
     },
-    permissions: ["READ_EXTERNAL_STORAGE", "WRITE_EXTERNAL_STORAGE"],
   },
   extra: {
     eas: {
@@ -40,7 +35,7 @@ const defineConfig = (_ctx: ConfigContext): ExpoConfig => ({
     },
     CLERK_PUBLISHABLE_KEY,
   },
-  plugins: ["./expo-plugins/with-modify-gradle.js", "expo-image-picker"],
+  plugins: ["./expo-plugins/with-modify-gradle.js"],
 });
 
 export default defineConfig;

--- a/apps/expo/app.config.ts
+++ b/apps/expo/app.config.ts
@@ -22,12 +22,17 @@ const defineConfig = (_ctx: ConfigContext): ExpoConfig => ({
   ios: {
     supportsTablet: true,
     bundleIdentifier: "your.bundle.identifier",
+    infoPlist: {
+      NSPhotoLibraryUsageDescription:
+        "This app needs access to your photo library for OCR processing.",
+    },
   },
   android: {
     adaptiveIcon: {
       foregroundImage: "./assets/icon.png",
       backgroundColor: "#ffffff",
     },
+    permissions: ["READ_EXTERNAL_STORAGE", "WRITE_EXTERNAL_STORAGE"],
   },
   extra: {
     eas: {
@@ -35,7 +40,7 @@ const defineConfig = (_ctx: ConfigContext): ExpoConfig => ({
     },
     CLERK_PUBLISHABLE_KEY,
   },
-  plugins: ["./expo-plugins/with-modify-gradle.js"],
+  plugins: ["./expo-plugins/with-modify-gradle.js", "expo-image-picker"],
 });
 
 export default defineConfig;

--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "expo start",
     "with-env": "dotenv -e ./.env --",
-    "dev": "pnpm with-env expo start --android",
+    "dev": "pnpm with-env expo start --ios",
     "clean": "rm -rf .expo .turbo node_modules",
     "android": "expo start --android",
     "ios": "expo start --ios",

--- a/apps/expo/src/components/PermissionAlert.tsx
+++ b/apps/expo/src/components/PermissionAlert.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { Linking, Platform, Alert } from "react-native";
+
+import { translate, tokens } from "../i18n";
+
+const openAppSettings = () => {
+  if (Platform.OS === "ios") {
+    Linking.openURL("app-settings:");
+  } else {
+    Linking.openSettings();
+  }
+};
+
+export const PermissionAlert: React.FC = () => {
+  Alert.alert(
+    translate(tokens.alerts.permissionRequired),
+    translate(tokens.alerts.permissionRequiredMessage),
+    [
+      { text: translate(tokens.alerts.alertCancelBtn), style: "cancel" },
+      {
+        text: translate(tokens.alerts.alertOpenSettingsBtn),
+        onPress: openAppSettings,
+      },
+    ],
+  );
+
+  return null;
+};

--- a/apps/expo/src/hooks/useImageUpload.ts
+++ b/apps/expo/src/hooks/useImageUpload.ts
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import * as Crypto from "expo-crypto";
 import * as ImagePicker from "expo-image-picker";
-import { Linking, Platform, Alert } from "react-native";
 
 import { trpc } from "../utils/trpc";
 import { translate, tokens } from "../i18n";
@@ -31,16 +30,10 @@ export const useImageUpload = () => {
   const [status, setStatus] = useState<UploadStatus>(UploadStatus.IDLE);
   const [error, setError] = useState<string | null>(null);
 
+  const [showPermissionAlert, setShowPermissionAlert] = useState(false);
+
   const { mutateAsync: fetchPresignedUrl } = trpc.s3.getSignedUrl.useMutation();
   const { mutateAsync: detectTextMutation } = trpc.s3.detectText.useMutation();
-
-  const openAppSettings = () => {
-    if (Platform.OS === "ios") {
-      Linking.openURL("app-settings:");
-    } else {
-      Linking.openSettings();
-    }
-  };
 
   const pickImage = async () => {
     // Reset status and error states
@@ -53,17 +46,7 @@ export const useImageUpload = () => {
     if (status !== "granted") {
       setError(translate(tokens.alerts.missingLibraryPermission));
       setStatus(UploadStatus.FAILED);
-      Alert.alert(
-        translate(tokens.alerts.permissionRequired),
-        translate(tokens.alerts.permissionRequiredMessage),
-        [
-          { text: translate(tokens.alerts.alertCancelBtn), style: "cancel" },
-          {
-            text: translate(tokens.alerts.alertOpenSettingsBtn),
-            onPress: openAppSettings,
-          },
-        ],
-      );
+      setShowPermissionAlert(true);
       return;
     }
 
@@ -146,5 +129,13 @@ export const useImageUpload = () => {
     }
   };
 
-  return { image, pickImage, uploadImage, detectText, status, error };
+  return {
+    image,
+    pickImage,
+    uploadImage,
+    detectText,
+    showPermissionAlert,
+    status,
+    error,
+  };
 };

--- a/apps/expo/src/screens/ocrScan.tsx
+++ b/apps/expo/src/screens/ocrScan.tsx
@@ -82,7 +82,7 @@ export const OcrScanScreen = ({ navigation }: OcrScanScreenProps) => {
                 style={{
                   aspectRatio: firstImage.width / firstImage.height,
                   height: isPortrait(firstImage)
-                    ? screenHeight * 0.6
+                    ? screenHeight * 0.5
                     : screenHeight * 0.25,
                 }}
                 className="w-full rounded-xl bg-primary-lightest"

--- a/apps/expo/src/screens/ocrScan.tsx
+++ b/apps/expo/src/screens/ocrScan.tsx
@@ -25,7 +25,7 @@ const screenHeight = Dimensions.get("window").height;
 type OcrScanScreenProps = StackScreenProps<OcrStackParamList, "Scaner">;
 
 export const OcrScanScreen = ({ navigation }: OcrScanScreenProps) => {
-  const { image, pickImage, uploadImage, detectText, status } =
+  const { image, pickImage, uploadImage, detectText, status, error } =
     useImageUpload();
   const [hasScanned, setHasScanned] = useState(false);
 
@@ -88,7 +88,11 @@ export const OcrScanScreen = ({ navigation }: OcrScanScreenProps) => {
 
           <View className="flex items-center p-1">
             <Text className="text-center text-xl">
-              {hasScanned ? `${status.toLowerCase()}` : " "}
+              {status === "FAILED"
+                ? error
+                : hasScanned
+                ? `${status.toLowerCase()}`
+                : " "}
             </Text>
           </View>
         </Animated.View>

--- a/apps/expo/src/screens/ocrScan.tsx
+++ b/apps/expo/src/screens/ocrScan.tsx
@@ -19,14 +19,22 @@ import {
   getFirstImage,
   isPortrait,
 } from "../hooks/useImageUpload";
+import { PermissionAlert } from "../components/PermissionAlert";
 
 const screenHeight = Dimensions.get("window").height;
 
 type OcrScanScreenProps = StackScreenProps<OcrStackParamList, "Scaner">;
 
 export const OcrScanScreen = ({ navigation }: OcrScanScreenProps) => {
-  const { image, pickImage, uploadImage, detectText, status, error } =
-    useImageUpload();
+  const {
+    image,
+    pickImage,
+    uploadImage,
+    detectText,
+    showPermissionAlert,
+    status,
+    error,
+  } = useImageUpload();
   const [hasScanned, setHasScanned] = useState(false);
 
   const firstImage = getFirstImage(image);
@@ -132,6 +140,7 @@ export const OcrScanScreen = ({ navigation }: OcrScanScreenProps) => {
           </Animated.View>
         </Animated.View>
       </ScrollView>
+      {showPermissionAlert && <PermissionAlert />}
     </SafeAreaView>
   );
 };

--- a/apps/expo/src/translations/en.ts
+++ b/apps/expo/src/translations/en.ts
@@ -70,6 +70,14 @@ const en = {
   drawerScaner: "Scaner",
   drawerProfile: "Profile",
   drawerLogout: "Logout",
+
+  // Alerts & Messages
+  missingLibraryPermission: "Missing media library permission.",
+  permissionRequired: "Permission Required",
+  permissionRequiredMessage:
+    "This app needs access to your photo library for OCR processing. Please go to settings and grant permission.",
+  alertCancelBtn: "Cancel",
+  alertOpenSettingsBtn: "Open Settings",
 };
 
 export default en;

--- a/apps/expo/src/translations/pl.ts
+++ b/apps/expo/src/translations/pl.ts
@@ -69,6 +69,14 @@ const pl = {
   drawerScaner: "Skaner",
   drawerProfile: "Profil",
   drawerLogout: "Wyloguj",
+
+  // Alerts & Messages
+  missingLibraryPermission: "Brak uprawnień dostępu do galerii.",
+  permissionRequired: "Wymagane uprawnienia",
+  permissionRequiredMessage:
+    "Aby kontynuować, musisz udzielić uprawnień do galerii zdjęć.",
+  alertCancel: "Anuluj",
+  alertOpenSettingsBtn: "Otwórz ustawienia",
 };
 
 export default pl;

--- a/apps/expo/src/translations/pl.ts
+++ b/apps/expo/src/translations/pl.ts
@@ -71,10 +71,10 @@ const pl = {
   drawerLogout: "Wyloguj",
 
   // Alerts & Messages
-  missingLibraryPermission: "Brak uprawnień dostępu do galerii.",
+  missingLibraryPermission: "Brak uprawnień dostępu do galerii zdjęć.",
   permissionRequired: "Wymagane uprawnienia",
   permissionRequiredMessage:
-    "Aby kontynuować, musisz udzielić uprawnień do galerii zdjęć.",
+    "Aby kontynuować, udziel uprawnień dostępu do galerii zdjęć.",
   alertCancel: "Anuluj",
   alertOpenSettingsBtn: "Otwórz ustawienia",
 };

--- a/apps/expo/src/translations/tokens.ts
+++ b/apps/expo/src/translations/tokens.ts
@@ -92,6 +92,14 @@ export const ocrTaskSelection = {
   respondToText: RespondToText,
 };
 
+export enum Alerts {
+  missingLibraryPermission = "missingLibraryPermission",
+  permissionRequired = "permissionRequired",
+  permissionRequiredMessage = "permissionRequiredMessage",
+  alertCancelBtn = "alertCancelBtn",
+  alertOpenSettingsBtn = "alertOpenSettingsBtn",
+}
+
 export const tokens = {
   screens: {
     welcome: WelcomeScreen,
@@ -108,4 +116,5 @@ export const tokens = {
     ocrTasks: ocrTaskSelection,
   },
   drawer: DrawerPanel,
+  alerts: Alerts,
 };


### PR DESCRIPTION
For the time being, for iOS for the `ImagePicker.requestMediaLibraryPermissionsAsync` the workaround is to use `allowsEditing: true` - otherwise iOS is confused and says `Cannot handle `public.png/jpg` media type`.